### PR TITLE
ci: add minimum workflow permissions

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -12,6 +12,9 @@ on:
         type: string
         description: "Python version to use"
 
+permissions:
+  contents: read
+
 env:
   WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -12,6 +12,9 @@ on:
         type: string
         description: "Python version to use"
 
+permissions:
+  contents: read
+
 env:
   UV_FROZEN: "true"
   UV_NO_SYNC: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     strategy:
@@ -35,7 +38,6 @@ jobs:
     with:
       working-directory: .
       python-version: ${{ matrix.python-version }}
-    secrets: inherit
   test:
     strategy:
       matrix:
@@ -54,5 +56,4 @@ jobs:
     with:
       working-directory: .
       python-version: ${{ matrix.python-version }}
-    secrets: inherit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ on:
         default: false
         description: "Release from a non-main branch (danger!)"
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.11"
   UV_FROZEN: "true"
@@ -105,7 +108,7 @@ jobs:
           path: ${{ inputs.working-directory }}/dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
         with:
           packages-dir: ${{ inputs.working-directory }}/dist/
           verbose: true
@@ -141,7 +144,7 @@ jobs:
           path: ${{ inputs.working-directory }}/dist/
 
       - name: Create Tag
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           artifacts: "dist/*"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add top-level `permissions: contents: read` to all four workflow files (`_lint.yml`, `_test.yml`, `ci.yml`, `release.yml`) — fixes Rules 1 & 4 (missing permissions block / reusable workflow without permissions)
- Remove `secrets: inherit` from `ci.yml` — the called reusable workflows use no secrets, so this was unnecessary exposure on `pull_request` triggers
- SHA-pin `pypa/gh-action-pypi-publish@release/v1` → `ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e` in `release.yml` — fixes Rule 6
- SHA-pin `ncipollo/release-action@v1` → `339a81892b84b4eeb0f6e744e4574d79d0d9b8dd` in `release.yml` — fixes Rule 6

## Test plan

- [x] CI passes on this PR (lint + test jobs in `ci.yml` still work without `secrets: inherit`)
- [x] Verify `release.yml` jobs still have correct job-level permissions (`publish: id-token: write`, `mark-release: contents: write`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)